### PR TITLE
Clean up README docs and add Claude Code/Codex MCP configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,35 @@
-# AI Coding Tookit for Plaid
+# AI Coding Toolkit for Plaid
 
 A comprehensive toolkit designed to accelerate Plaid integration development using AI coding assistants. This repository provides sandbox MCP tools (mock data generation, documentation search capabilities, etc.) and product-specific guides to help developers build Plaid integrations faster and more efficiently with AI assistance.
 
 ## Repository Structure
 
 - `/sandbox`: Contains a sandbox MCP server implementation that helps developers integrate with Plaid more quickly by providing mock data and sandbox API access.
-- `/rules`: Contains product-specific guides that can be used either as direct prompts for AI assistants or as Cursor rules to accelerate Plaid integration development.
+- `/rules`: Contains product-specific guides that can be used as instructions for AI coding assistants to accelerate Plaid integration development.
 
 ## Sandbox MCP Server
 
-The sandbox MCP server located in `/sandbox` directory provides a set of tools to facilitate faster integration with Plaid. It offers:
-
-- Mock financial data generation
-- Plaid documentation search
-- Sandbox API access tokens
-- Webhook simulation
-
-This sandbox environment allows developers to test their Plaid integrations without using real financial data.
-
-### Key Features
+The sandbox MCP server in `/sandbox` provides tools to test Plaid integrations without using real financial data:
 
 - **Generate mock financial data** for testing purposes
 - **Search Plaid documentation** for relevant API information
 - **Obtain sandbox access tokens** for testing
 - **Simulate webhooks** to test application handling
 
-### Getting Started
-
-To use the sandbox MCP server, navigate to the `/sandbox` directory and follow the instructions in its README.
-
-```bash
-cd sandbox
-# Follow instructions in sandbox/README.md for setup and usage
-```
+See [sandbox/README.md](sandbox/README.md) for setup instructions across Claude Code, Cursor, Codex, VS Code, Claude Desktop, and Zed.
 
 ## Rules for AI Integration
 
-The `/rules` directory contains comprehensive guides for various Plaid products and features. These guides can be used in two ways:
+The `/rules` directory contains product-specific guides for Plaid integrations. You can use them in two ways:
 
-1. **Direct Prompts**: Copy the content directly into your conversations with AI assistants to provide them with specialized knowledge about Plaid products.
-
-2. **Cursor Rules**: Import them as Cursor rules to enable your AI coding assistant to automatically understand Plaid's integration patterns and best practices.
+1. **Project instructions**: Drop the content into your AI tool's instructions file (`CLAUDE.md` for Claude Code, `AGENTS.md` for Codex, Cursor rules, etc.) so the assistant has the context automatically.
+2. **Direct prompts**: Paste the content directly into a conversation with your AI assistant.
 
 Using these rules significantly accelerates development by giving AI models the context they need to generate code for Plaid integrations.
 
 > [!WARNING]
-These guides are designed to be used for the purpose of building a sample Plaid integration with the use of AI coding tools. You are solely responsible for ensuring the correctness, legality, security, privacy, and compliance of your own app and Plaid integration. This guide is provided under the MIT license and is provided as-is and without warranty of any kind.
+> These guides are designed to be used for the purpose of building a sample Plaid integration with the use of AI coding tools. You are solely responsible for ensuring the correctness, legality, security, privacy, and compliance of your own app and Plaid integration. This guide is provided under the MIT license and is provided as-is and without warranty of any kind.
 
 ## License
 
-This project is licensed under the MIT License - see the LICENSE file for details. 
+This project is licensed under the MIT License - see the LICENSE file for details.

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -28,22 +28,17 @@ A Model Context Protocol server for facilitating integration with Plaid. This se
 
 1. Sign in to your [Plaid Developer Dashboard](https://developer.plaid.com) account
 2. Navigate to **Developers** → **[Keys](https://dashboard.plaid.com/developers/keys)**
-3. Locate your **sandbox credentials** as illustrated in the screenshot below.
+3. Locate your **sandbox credentials**.
 
->[!Important]
-All `PLAID_CLIENT_ID` and `PLAID_SECRET` references in the following MCP configuration use **sandbox credentials**.
+> [!IMPORTANT]
+> All `PLAID_CLIENT_ID` and `PLAID_SECRET` references in the following MCP configuration use **sandbox credentials**.
 
+> [!NOTE]
+> All snippets below use `uvx`. If you installed via pip, swap `uvx mcp-server-plaid` for `python -m mcp_server_plaid`.
 
-<img width="890" alt="image" src="https://github.com/user-attachments/assets/d0c0030a-93c9-4d3f-bb21-1f12b5c1e8e9" />
+### Usage with Claude Code
 
-
-
-### Usage with Claude Desktop
-
-Add this to your `claude_desktop_config.json`:
-
-<details>
-<summary>Using uvx</summary>
+Add this to `.mcp.json` in your project root (or `~/.claude.json` for a user-scoped install):
 
 ```json
 {
@@ -61,38 +56,20 @@ Add this to your `claude_desktop_config.json`:
   }
 }
 ```
-</details>
 
-<details>
-<summary>Using pip installation</summary>
+Or use the CLI:
 
-```json
-{
-  "mcpServers": {
-    "plaid": {
-      "command": "python",
-      "args": [
-        "-m",
-        "mcp_server_plaid",
-        "--client-id",
-        "YOUR_PLAID_CLIENT_ID",
-        "--secret",
-        "YOUR_PLAID_SECRET"
-      ]
-    }
-  }
-}
+```bash
+claude mcp add plaid -- uvx mcp-server-plaid --client-id YOUR_PLAID_CLIENT_ID --secret YOUR_PLAID_SECRET
 ```
-</details>
 
 ### Usage with Cursor
-For quick installation, use the one-click installation button 
+
+For quick installation, use the one-click installation button.
 
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=plaid&config=eyJjb21tYW5kIjoidXZ4IG1jcC1zZXJ2ZXItcGxhaWQiLCJlbnYiOnsiUExBSURfQ0xJRU5UX0lEIjoiQUREX1lPVVJfQ0xJRU5UX0lEIiwiUExBSURfU0VDUkVUIjoiQUREX1lPVVJfQVBJX1NFQ1JFVCJ9fQ%3D%3D)
 
-For manual installation, add the following JSON block to Cursor MCP config file,
-<details>
-<summary>Using uvx</summary>
+For manual installation, add the following JSON block to Cursor MCP config file.
 
 ```json
 {
@@ -110,33 +87,20 @@ For manual installation, add the following JSON block to Cursor MCP config file,
   }
 }
 ```
-</details>
 
-<details>
-<summary>Using pip installation</summary>
+### Usage with Codex
 
-```json
-{
-  "mcpServers": {
-    "plaid": {
-      "command": "python",
-      "args": [
-        "-m",
-        "mcp_server_plaid",
-        "--client-id",
-        "YOUR_PLAID_CLIENT_ID",
-        "--secret",
-        "YOUR_PLAID_SECRET"
-      ]
-    }
-  }
-}
+Add this to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.plaid]
+command = "uvx"
+args = ["mcp-server-plaid", "--client-id", "YOUR_PLAID_CLIENT_ID", "--secret", "YOUR_PLAID_SECRET"]
 ```
-</details>
 
 ### Usage with VS Code
 
-For quick installation, use one of the one-click installation buttons below,
+For quick installation, use one of the one-click installation buttons below.
 
 [![Install with UV in VS Code](https://img.shields.io/badge/VS_Code-UV-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=plaid&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22client_id%22%2C%22description%22%3A%22Plaid%20Client%20ID%22%2C%22password%22%3Afalse%7D%2C%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22secret%22%2C%22description%22%3A%22Plaid%20Secret%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-server-plaid%22%5D%2C%22env%22%3A%7B%22PLAID_CLIENT_ID%22%3A%22%24%7Binput%3Aclient_id%7D%22%2C%22PLAID_SECRET%22%3A%22%24%7Binput%3Asecret%7D%22%7D%7D) [![Install with UV in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-UV-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=plaid&inputs=%5B%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22client_id%22%2C%22description%22%3A%22Plaid%20Client%20ID%22%2C%22password%22%3Afalse%7D%2C%7B%22type%22%3A%22promptString%22%2C%22id%22%3A%22secret%22%2C%22description%22%3A%22Plaid%20Secret%22%2C%22password%22%3Atrue%7D%5D&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-server-plaid%22%5D%2C%22env%22%3A%7B%22PLAID_CLIENT_ID%22%3A%22%24%7Binput%3Aclient_id%7D%22%2C%22PLAID_SECRET%22%3A%22%24%7Binput%3Asecret%7D%22%7D%7D&quality=insiders)
 
@@ -145,9 +109,6 @@ For manual installation, add the following JSON block to your User Settings (JSO
 Optionally, you can add it to a file called `.vscode/mcp.json` in your workspace. This will allow you to share the configuration with others.
 
 > Note that the `mcp` key is needed when using the `mcp.json` file.
-
-<details>
-<summary>Using uvx</summary>
 
 ```json
 {
@@ -179,14 +140,31 @@ Optionally, you can add it to a file called `.vscode/mcp.json` in your workspace
   }
 }
 ```
-</details>
 
-### Usage with [Zed](https://github.com/zed-industries/zed)
+### Usage with Claude Desktop
 
-Add to your Zed settings.json:
+Add this to your `claude_desktop_config.json`:
 
-<details>
-<summary>Using uvx</summary>
+```json
+{
+  "mcpServers": {
+    "plaid": {
+      "command": "uvx",
+      "args": [
+        "mcp-server-plaid",
+        "--client-id",
+        "YOUR_PLAID_CLIENT_ID",
+        "--secret",
+        "YOUR_PLAID_SECRET"
+      ]
+    }
+  }
+}
+```
+
+### Usage with Zed
+
+Add to your Zed `settings.json`:
 
 ```json
 {
@@ -206,29 +184,6 @@ Add to your Zed settings.json:
    }
 }
 ```
-</details>
-
-<details>
-<summary>Using pip installation</summary>
-
-```json
-{
-  "context_servers": {
-    "mcp-server-plaid": {
-      "command": "python",
-      "args": [
-        "-m",
-        "mcp_server_plaid",
-        "--client-id",
-        "YOUR_PLAID_CLIENT_ID",
-        "--secret",
-        "YOUR_PLAID_SECRET"
-      ]
-    }
-  }
-}
-```
-</details>
 
 ## Debugging
 


### PR DESCRIPTION
## Summary

Cleans up both READMEs and adds MCP configuration sections for Claude Code and Codex.

### `sandbox/README.md`
- Add **Claude Code** (`.mcp.json` snippet + `claude mcp add` one-liner) and **Codex** (`~/.codex/config.toml`).
- Reorder tool sections by approximate usage: Claude Code → Cursor → Codex → VS Code → Claude Desktop → Zed.
- Remove the credentials-page screenshot — the surrounding steps already explain where to find the keys.
- Drop the `<details>` collapsibles so snippets are visible inline (a setup doc shouldn't hide its setup behind clicks).
- Consolidate the duplicated `pip` variants into a single note up top.
- Misc copy/formatting nits (trailing whitespace, commas → periods, callout prefix).

### `README.md`
- Fix "Tookit" → "Toolkit" typo in the title.
- Collapse three overlapping sandbox descriptions into one and link out to `sandbox/README.md` for the per-tool configs.
- Make the rules-directory framing tool-agnostic (was Cursor-only) — mentions `CLAUDE.md`, `AGENTS.md`, Cursor rules.
- Fix the `[!WARNING]` callout so the body actually renders inside the block.
- Drop the trivial `cd sandbox` snippet.