### PR TITLE
Fix Cursor one-click install link

### DIFF
--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -67,7 +67,7 @@ claude mcp add plaid -- uvx mcp-server-plaid --client-id YOUR_PLAID_CLIENT_ID --
 
 For quick installation, use the one-click installation button.
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=plaid&config=eyJjb21tYW5kIjoidXZ4IG1jcC1zZXJ2ZXItcGxhaWQiLCJlbnYiOnsiUExBSURfQ0xJRU5UX0lEIjoiQUREX1lPVVJfQ0xJRU5UX0lEIiwiUExBSURfU0VDUkVUIjoiQUREX1lPVVJfQVBJX1NFQ1JFVCJ9fQ%3D%3D)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=plaid&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJtY3Atc2VydmVyLXBsYWlkIl0sImVudiI6eyJQTEFJRF9DTElFTlRfSUQiOiJBRERfWU9VUl9DTElFTlRfSUQiLCJQTEFJRF9TRUNSRVQiOiJBRERfWU9VUl9BUElfU0VDUkVUIn19)
 
 For manual installation, add the following JSON block to Cursor MCP config file.
 


### PR DESCRIPTION
The "Add to Cursor" button in `sandbox/README.md` was silently failing because the base64-encoded config used the wrong shape.

Decoded before:
```json
{"command":"uvx mcp-server-plaid","env":{"PLAID_CLIENT_ID":"ADD_YOUR_CLIENT_ID","PLAID_SECRET":"ADD_YOUR_API_SECRET"}}
```

Decoded after:
```json
{"command":"uvx","args":["mcp-server-plaid"],"env":{"PLAID_CLIENT_ID":"ADD_YOUR_CLIENT_ID","PLAID_SECRET":"ADD_YOUR_API_SECRET"}}
```

Cursor's install-mcp link expects `command` to be just the executable, with arguments in a separate `args` array (same shape as `mcp.json`). Concatenating them into the `command` string makes Cursor try to spawn `"uvx mcp-server-plaid"` as a single binary, which fails.

Refs: <https://cursor.com/docs/context/mcp/install-links>

## Test plan
- [ ] Click the badge on the rendered README and confirm Cursor opens the install dialog with the correct command/args populated
- [ ] After install, replace the `ADD_YOUR_*` placeholders and verify the server starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Session: 80ee54fa-3880-4c3c-b81d-9bf74c3adb2c