### PR TITLE
Use cursor:// deeplink for Cursor install button

### DIFF
--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -67,7 +67,7 @@ claude mcp add plaid -- uvx mcp-server-plaid --client-id YOUR_PLAID_CLIENT_ID --
 
 For quick installation, use the one-click installation button.
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=plaid&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJtY3Atc2VydmVyLXBsYWlkIl0sImVudiI6eyJQTEFJRF9DTElFTlRfSUQiOiJBRERfWU9VUl9DTElFTlRfSUQiLCJQTEFJRF9TRUNSRVQiOiJBRERfWU9VUl9BUElfU0VDUkVUIn19)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](cursor://anysphere.cursor-deeplink/mcp/install?name=plaid&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJtY3Atc2VydmVyLXBsYWlkIl0sImVudiI6eyJQTEFJRF9DTElFTlRfSUQiOiJBRERfWU9VUl9DTElFTlRfSUQiLCJQTEFJRF9TRUNSRVQiOiJBRERfWU9VUl9BUElfU0VDUkVUIn19)
 
 For manual installation, add the following JSON block to Cursor MCP config file.
 


### PR DESCRIPTION
Follow-up to #31. That PR fixed the base64 config shape, but the badge link still points at `https://cursor.com/install-mcp?...`, which doesn't actually trigger an install when clicked from a rendered README.

Per [Cursor's install-links docs](https://cursor.com/docs/context/mcp/install-links), the canonical scheme is `cursor://anysphere.cursor-deeplink/mcp/install?...`. Commit ab27f51 originally used this scheme; 5bd10c2 removed the button, and a6a62af reintroduced it with the broken https form.

## Test plan
- [ ] Click the badge on the rendered README; confirm the browser hands off to Cursor and the install dialog appears
- [ ] Confirm the dialog shows `command=uvx`, `args=["mcp-server-plaid"]`, and the two env placeholders
- [ ] Replace the `ADD_YOUR_*` placeholders and verify the server starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Session: 80ee54fa-3880-4c3c-b81d-9bf74c3adb2c