### PR TITLE
Fix Cursor install badge URL; trim host list in top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The sandbox MCP server in `/sandbox` provides tools to test Plaid integrations w
 - **Obtain sandbox access tokens** for testing
 - **Simulate webhooks** to test application handling
 
-See [sandbox/README.md](sandbox/README.md) for setup instructions across Claude Code, Cursor, Codex, VS Code, Claude Desktop, and Zed.
+See [sandbox/README.md](sandbox/README.md) for setup instructions.
 
 ## Rules for AI Integration
 

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -67,7 +67,7 @@ claude mcp add plaid -- uvx mcp-server-plaid --client-id YOUR_PLAID_CLIENT_ID --
 
 For quick installation, use the one-click installation button.
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](cursor://anysphere.cursor-deeplink/mcp/install?name=plaid&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJtY3Atc2VydmVyLXBsYWlkIl0sImVudiI6eyJQTEFJRF9DTElFTlRfSUQiOiJBRERfWU9VUl9DTElFTlRfSUQiLCJQTEFJRF9TRUNSRVQiOiJBRERfWU9VUl9BUElfU0VDUkVUIn19)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=plaid&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJtY3Atc2VydmVyLXBsYWlkIl0sImVudiI6eyJQTEFJRF9DTElFTlRfSUQiOiJBRERfWU9VUl9DTElFTlRfSUQiLCJQTEFJRF9TRUNSRVQiOiJBRERfWU9VUl9BUElfU0VDUkVUIn19)
 
 For manual installation, add the following JSON block to Cursor MCP config file.
 


### PR DESCRIPTION
Two README touch-ups.

## 1. Cursor install badge URL (`sandbox/README.md`); third time's the charm.

Follow-up to #31 and #32. Both prior fixes left the badge non-functional:

- **#31** corrected the base64 config shape but kept `https://cursor.com/install-mcp?...`, which now returns 404.
- **#32** switched to the `cursor://anysphere.cursor-deeplink/mcp/install` deeplink. GitHub's markdown sanitizer strips non-http(s) schemes from rendered link hrefs, so clicking the badge falls through to the camo image URL instead of opening Cursor.

The fix is the locale-prefixed path Cursor migrated to: `https://cursor.com/en/install-mcp?...`. It 307-redirects to `/en-US/install-mcp` and serves the install handoff page that triggers the `cursor://` deeplink. github/github-mcp-server applied the same fix in their [Cursor installation guide](https://github.com/github/github-mcp-server/blob/main/docs/installation-guides/install-cursor.md) (see [issue #860](https://github.com/github/github-mcp-server/issues/860)).

## 2. Trim host list from top-level README

The sandbox setup pointer used to enumerate every host. Dropped the list — the link is enough, and it goes stale whenever the host set changes.

## Test plan
- [ ] On the rendered README, click the Cursor install badge and confirm the browser navigates to `cursor.com/en-US/install-mcp` and hands off to Cursor
- [ ] Confirm the Cursor install dialog shows `command=uvx`, `args=["mcp-server-plaid"]`, and the two env placeholders
- [ ] Replace the `ADD_YOUR_*` placeholders and verify the server starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)