### PR TITLE
Fix broken Plaid links in signal and transfer rule guides

### DIFF
--- a/rules/signal_guide.md
+++ b/rules/signal_guide.md
@@ -18,9 +18,9 @@ This guide is designed to be used for the purpose of building a sample Plaid int
 
 Before starting the integration, ensure the following:
 
-- You have a [Plaid Developer Dashboard](https:/dashboard.plaid.com) account.
+- You have a [Plaid Developer Dashboard](https://dashboard.plaid.com) account.
 - You have obtained your **client ID** and **Sandbox secret** from the dashboard.
-- You are working in the [Sandbox environment](https:/plaid.com/docs/sandbox/overview) where test credentials and institutions are available.
+- You are working in the [Sandbox environment](https://plaid.com/docs/sandbox/overview) where test credentials and institutions are available.
 - Your development environment can serve both **frontend** and **backend** logic. The backend must be able to securely manage sensitive credentials and handle API calls.
 - You have applied for and received approval for Signal Transaction Scores (or have received Sandbox access while waiting for approval).
 
@@ -30,7 +30,7 @@ Before beginning your integration, first create a ruleset in the Plaid Dashboard
 
 ### 1.1 Access Signal Rules Dashboard
 
-- Navigate to the [Signal Rules Dashboard](https:/dashboard.plaid.com/signal/risk-profiles) page.
+- Navigate to the [Signal Rules Dashboard](https://dashboard.plaid.com/signal/risk-profiles) page.
 - Toggle Sandbox mode in the top right corner.
 
 ### 1.2 Create a Ruleset
@@ -41,7 +41,7 @@ Before beginning your integration, first create a ruleset in the Plaid Dashboard
 
 ## Step 2: Backend - Create a Link Token
 
-The Link Token is a short-lived token created server-side that configures the [Plaid Link](https:/plaid.com/docs/link) flow. This token must be generated on your backend and passed to the frontend.
+The Link Token is a short-lived token created server-side that configures the [Plaid Link](https://plaid.com/docs/link) flow. This token must be generated on your backend and passed to the frontend.
 
 ### 2.1 API Endpoint
 

--- a/rules/transfer_guide.md
+++ b/rules/transfer_guide.md
@@ -24,14 +24,14 @@ Follow the appropriate respective guide.
 
 ## Prerequisites
 
-- You have a [Plaid Developer Dashboard](mdc:https:/dashboard.plaid.com) account.
+- You have a [Plaid Developer Dashboard](https://dashboard.plaid.com) account.
 - You have obtained your **client ID** and **Sandbox secret** from the dashboard.
-- You are working in the [Sandbox environment](mdc:https:/plaid.com/docs/sandbox/overview) where test credentials and institutions are available.
+- You are working in the [Sandbox environment](https://plaid.com/docs/sandbox/overview) where test credentials and institutions are available.
 - Your development environment can serve both **frontend** and **backend** logic. The backend must be able to securely manage sensitive credentials and handle API calls.
 
 ## Step 1: Backend - Create a Link Token
 
-The Link Token is a short-lived token created server-side that configures the [Plaid Link](mdc:https:/plaid.com/docs/link) flow. This token must be generated on your backend and passed to the frontend.
+The Link Token is a short-lived token created server-side that configures the [Plaid Link](https://plaid.com/docs/link) flow. This token must be generated on your backend and passed to the frontend.
 
 ### 1.1 API Endpoint
 


### PR DESCRIPTION
## Summary

Two issues in `rules/signal_guide.md` and `rules/transfer_guide.md` broke the hyperlinks to `dashboard.plaid.com` and `plaid.com/docs`:

1. URLs used a single-slash scheme `https:/host` instead of `https://host`, so the rendered links pointed at an invalid URL.
2. `transfer_guide.md` additionally prefixed each link with the Cursor-only `mdc:` scheme. The repo's README advertises these rule files for use in Claude Code, Codex, and other non-Cursor AI tools where `mdc:` is not recognized.

Strip the `mdc:` prefix and restore `https://` on all 7 affected links so the rules render and click through correctly in every supported AI tool.

## Affected links

| File | Line | Before | After |
| --- | --- | --- | --- |
| signal_guide.md | 21 | `https:/dashboard.plaid.com` | `https://dashboard.plaid.com` |
| signal_guide.md | 23 | `https:/plaid.com/docs/sandbox/overview` | `https://plaid.com/docs/sandbox/overview` |
| signal_guide.md | 33 | `https:/dashboard.plaid.com/signal/risk-profiles` | `https://dashboard.plaid.com/signal/risk-profiles` |
| signal_guide.md | 44 | `https:/plaid.com/docs/link` | `https://plaid.com/docs/link` |
| transfer_guide.md | 27 | `mdc:https:/dashboard.plaid.com` | `https://dashboard.plaid.com` |
| transfer_guide.md | 29 | `mdc:https:/plaid.com/docs/sandbox/overview` | `https://plaid.com/docs/sandbox/overview` |
| transfer_guide.md | 34 | `mdc:https:/plaid.com/docs/link` | `https://plaid.com/docs/link` |