### PR TITLE
Fix broken Plaid doc/signup links in toolkit rules

### DIFF
--- a/rules/signal_guide.md
+++ b/rules/signal_guide.md
@@ -20,7 +20,7 @@ Before starting the integration, ensure the following:
 
 - You have a [Plaid Developer Dashboard](https://dashboard.plaid.com) account.
 - You have obtained your **client ID** and **Sandbox secret** from the dashboard.
-- You are working in the [Sandbox environment](https://plaid.com/docs/sandbox/overview) where test credentials and institutions are available.
+- You are working in the [Sandbox environment](https://plaid.com/docs/sandbox/) where test credentials and institutions are available.
 - Your development environment can serve both **frontend** and **backend** logic. The backend must be able to securely manage sensitive credentials and handle API calls.
 - You have applied for and received approval for Signal Transaction Scores (or have received Sandbox access while waiting for approval).
 

--- a/rules/transfer_guide.md
+++ b/rules/transfer_guide.md
@@ -26,7 +26,7 @@ Follow the appropriate respective guide.
 
 - You have a [Plaid Developer Dashboard](https://dashboard.plaid.com) account.
 - You have obtained your **client ID** and **Sandbox secret** from the dashboard.
-- You are working in the [Sandbox environment](https://plaid.com/docs/sandbox/overview) where test credentials and institutions are available.
+- You are working in the [Sandbox environment](https://plaid.com/docs/sandbox/) where test credentials and institutions are available.
 - Your development environment can serve both **frontend** and **backend** logic. The backend must be able to securely manage sensitive credentials and handle API calls.
 
 ## Step 1: Backend - Create a Link Token

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -26,7 +26,7 @@ A Model Context Protocol server for facilitating integration with Plaid. This se
 
 ### Obtaining API Credentials
 
-1. Sign in to your [Plaid Developer Dashboard](https://developer.plaid.com) account
+1. Sign in to your [Plaid Developer Dashboard](https://dashboard.plaid.com) account
 2. Navigate to **Developers** → **[Keys](https://dashboard.plaid.com/developers/keys)**
 3. Locate your **sandbox credentials**.
 


### PR DESCRIPTION
Two dead links: the Sandbox guide `/docs/sandbox/overview` (page removed; now `/docs/sandbox/`) in the Signal and Transfer rule guides, and the non-resolving `developer.plaid.com` host in `sandbox/README.md` (repointed to `dashboard.plaid.com`, already used elsewhere in the README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)