### PR TITLE
Pin mcp SDK below 2.0 and release 0.1.1

### DIFF
--- a/sandbox/pyproject.toml
+++ b/sandbox/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-server-plaid"
-version = "0.1.0"
+version = "0.1.1"
 description = "Model Context Protocol (MCP) server to build fast integration testing with Plaid Sandbox data."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -14,7 +14,7 @@ authors = [
 ]
 dependencies = [
     "httpx",
-    "mcp",
+    "mcp>=1.6,<2",
     "websockets",
     "plaid-python"
 ]

--- a/sandbox/src/mcp_server_plaid/server.py
+++ b/sandbox/src/mcp_server_plaid/server.py
@@ -8,6 +8,7 @@ It allows AI assistants to interact with Plaid's financial data APIs through the
 import asyncio
 import logging
 import sys
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any, Dict, List
 
 import click
@@ -29,7 +30,13 @@ logging.basicConfig(
 logger = logging.getLogger("plaid-mcp-server")
 
 # Constants
-__version__ = "0.1.1"
+try:
+    # Read from installed distribution metadata so dev releases, which stamp a
+    # generated version into pyproject.toml at publish time, report accurately.
+    __version__ = version("mcp-server-plaid")
+except PackageNotFoundError:
+    __version__ = "0.0.0+unknown"
+
 REQUEST_TIMEOUT = 30.0
 
 

--- a/sandbox/src/mcp_server_plaid/server.py
+++ b/sandbox/src/mcp_server_plaid/server.py
@@ -29,7 +29,7 @@ logging.basicConfig(
 logger = logging.getLogger("plaid-mcp-server")
 
 # Constants
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 REQUEST_TIMEOUT = 30.0
 
 

--- a/sandbox/src/mcp_server_plaid/server.py
+++ b/sandbox/src/mcp_server_plaid/server.py
@@ -29,14 +29,18 @@ logging.basicConfig(
 )
 logger = logging.getLogger("plaid-mcp-server")
 
-# Constants
+# Read the version from distribution metadata rather than a literal: the publish
+# workflow stamps a generated version into pyproject.toml, which a literal here
+# would not track.
 try:
-    # Read from installed distribution metadata so dev releases, which stamp a
-    # generated version into pyproject.toml at publish time, report accurately.
     __version__ = version("mcp-server-plaid")
 except PackageNotFoundError:
+    logger.warning(
+        "No mcp-server-plaid distribution metadata found; reporting version as unknown"
+    )
     __version__ = "0.0.0+unknown"
 
+# Constants
 REQUEST_TIMEOUT = 30.0
 
 


### PR DESCRIPTION
Fixes #37: `mcp` 2.0.0 removed the low-level decorators this server registers tools with, so `uvx mcp-server-plaid` crashes at startup. 

Needs a `formal` run of Publish Sandbox MCP after merge.

<!-- Claude Session: acf429ff-3d47-42f1-8d17-8203e37719f1 -->
